### PR TITLE
Fix: Crash in on_train_schedule_changed

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -238,7 +238,8 @@ local function on_train_schedule_changed(event)
   --is that an etc train?
   if global.trains[train.id] and global.trains[train.id].state == "working" then -- #FIXME waiting
     --if the current is no temp then give the train up
-    if train.schedule.records and
+    if train.schedule == nil or 
+        train.schedule.records and
         train.schedule.current and
         train.schedule.records[train.schedule.current].temporary == false then
       set_idle(train)


### PR DESCRIPTION
Problem: When a train's schedule is changed to be completely empty over just removing the current objective or altering the schedule train.schedule becomes nil, this results in the game crashing when train.schedule.records is attempted to be accessed

Fix: nil check the schedule when schedule changes are verfied, any behaviour after that is just treated as a regular schedule change  with no issues. 

Changes: only thing i added was a nil check on line 241 where the schedule is checked.